### PR TITLE
Using google play link instead of market

### DIFF
--- a/smartbanner.js
+++ b/smartbanner.js
@@ -101,7 +101,7 @@
             appMeta: 'google-play-app',
             iconRels: ['android-touch-icon', 'apple-touch-icon-precomposed', 'apple-touch-icon'],
             getStoreLink: function() {
-                return 'market://details?id=' + this.appId;
+                return 'http://play.google.com/store/apps/details?id=' + this.appId;
             }
         }
     };


### PR DESCRIPTION
Within Chrome App on a Nexus 5, the "market://details?id=...." would open the market but not open to the app. 

Using the newer: "http://play.google.com/store/apps/details?id=....' fixes this. 

And from testing on a Samsun Galaxy SIII, this appears to work as well. 

This is url is taken from: 
http://developer.android.com/distribute/tools/promote/linking.html

Cheers,
Adam
