### PR TITLE
Add to Bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,28 @@
+{
+  "name": "smart-app-banner",
+  "version": "1.0.0",
+  "homepage": "https://github.com/glibin/smart-app-banner",
+  "authors": [
+    "glibin.v@gmail.com"
+  ],
+  "description": "Lightweight smart app banner with no jQuery (or any other framework) requirement.",
+  "main": "smartbanner.js",
+  "moduleType": [
+    "globals"
+  ],
+  "keywords": [
+    "app",
+    "banner",
+    "android",
+    "ios"
+  ],
+  "license": "MIT",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "client/bower_components",
+    "test",
+    "tests"
+  ]
+}


### PR DESCRIPTION
Hi, 

This is a bit of a minor improvement (as it's possible to install manually via "bower install glibin/smartapp-banner", but it would help to have this package available in Bower as well.  :)

I've added a bower.json (which gets rid of some of the warnings when installing via the github repo path) but you will need to register the repo per here: http://bower.io/docs/creating-packages/

Thanks for creating this module!  It's nice that it's jquery-free.  
