### PR TITLE
Store language defaults to browser language

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Based on 'jQuery Smart Banner' by Arnold Daniels <arnold@jasny.net> https://gith
       new SmartBanner({
           daysHidden: 15,   // days to hide banner after close button is clicked (defaults to 15)
           daysReminder: 90, // days to hide banner after "VIEW" button is clicked (defaults to 90)
-          appStoreLanguage: 'us', // language code for the App Store (defaults to us)
+          appStoreLanguage: 'us', // language code for the App Store (defaults to user's browser language)
           title: 'MyPage',
           author: 'MyCompany LLC',
           button: 'VIEW',

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ var doc = require('get-doc');
 var root = doc && doc.documentElement;
 var cookie = require('cookie-cutter');
 var ua = require('ua-parser-js');
+var userLang = navigator.language.slice(-2) || navigator.userLanguage.slice(-2) || 'us';
 
 // platform dependent functionality
 var mixins = {
@@ -35,7 +36,7 @@ var SmartBanner = function(options) {
 	this.options = extend({}, {
 		daysHidden: 15,
 		daysReminder: 90,
-		appStoreLanguage: 'us', // Language code for App Store
+		appStoreLanguage: userLang, // Language code for App Store
 		button: 'OPEN', // Text for the install button
 		store: {
 			ios: 'On the App Store',

--- a/test/index.html
+++ b/test/index.html
@@ -40,7 +40,7 @@
 		new SmartBanner({
 				daysHidden: 15, // days to hide banner after close button is clicked (defaults to 15)
 				daysReminder: 90, // days to hide banner after "VIEW" button is clicked (defaults to 90)
-				appStoreLanguage: 'us', // language code for the App Store (defaults to us)
+				appStoreLanguage: 'us', // language code for the App Store (defaults to user's browser language)
 				title: 'KudaGo',
 				author: 'KudaGo Inc',
 				button: 'OPEN',


### PR DESCRIPTION
Now the scripts tries to detect the browser language and use it as the store language default. There is a fallback to 'us' if for whatever reason the browser does not give a language.

**PLEASE NOTE**: I couldn't replicate the dependencies stack, so the source file should be re-compiled by someone with the full-stack.

Signed-off-by: Emanuele feliziani.emanuele@gmail.com
