### PR TITLE
iOS Open App Store Instead of iTunes Store

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ var mixins = {
 		appMeta: 'apple-itunes-app',
 		iconRels: ['apple-touch-icon-precomposed', 'apple-touch-icon'],
 		getStoreLink: function () {
-			return 'https://itunes.apple.com/' + this.options.appStoreLanguage + '/app/id' + this.appId;
+			return 'https://itunes.apple.com/' + this.options.appStoreLanguage + '/app/id' + this.appId + "?mt=8";
 		}
 	},
 	android: {


### PR DESCRIPTION
Added "?mt=8" to the end of the iTunes URL to open the App Store instead of the iTunes Store.