### PR TITLE
add cookie AppId specific

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,12 +75,15 @@ var SmartBanner = function (options) {
 	// - user is on mobile safari for ios 6 or greater (iOS >= 6 has native support for SmartAppBanner)
 	// - running on standalone mode
 	// - user dismissed banner
+	this.appMeta = mixins[this.type].appMeta;
+	this.parseAppId();
+
 	var unsupported = !this.type || !this.options.store[this.type];
 	var isMobileSafari = (this.type === 'ios' && agent.browser.name === 'Mobile Safari' && parseInt(agent.os.version, 10) >= 6);
   
 	var runningStandAlone = navigator.standalone;
-	var userDismissed = cookie.get('smartbanner-closed');
-	var userInstalled = cookie.get('smartbanner-installed');
+	var userDismissed = cookie.get(this.appId + '-smartbanner-closed');
+	var userInstalled = cookie.get(this.appId + '-smartbanner-installed');
 
 	if (unsupported || isMobileSafari || runningStandAlone || userDismissed || userInstalled) {
 		return;
@@ -90,7 +93,7 @@ var SmartBanner = function (options) {
 
 	// - If we dont have app id in meta, dont display the banner
 	// - If opened in safari IOS, dont display the banner
-	if (!this.parseAppId() && agent.os.name === 'IOS' && agent.browser.name === 'Safari') {
+	if (!this.appId && agent.os.name === 'IOS' && agent.browser.name === 'Safari') {
 		return;
 	}
 
@@ -163,7 +166,7 @@ SmartBanner.prototype = {
 	},
 	close: function () {
 		this.hide();
-		cookie.set('smartbanner-closed', 'true', {
+		cookie.set(this.appId + '-smartbanner-closed', 'true', {
 			path: '/',
 			expires: new Date(Number(new Date()) + (this.options.daysHidden * 1000 * 60 * 60 * 24))
 		});
@@ -173,7 +176,7 @@ SmartBanner.prototype = {
 	},
 	install: function () {
 		this.hide();
-		cookie.set('smartbanner-installed', 'true', {
+		cookie.set(this.appId + '-smartbanner-installed', 'true', {
 			path: '/',
 			expires: new Date(Number(new Date()) + (this.options.daysReminder * 1000 * 60 * 60 * 24))
 		});


### PR DESCRIPTION
Current implementation doesn't support rendering multiple banners across pages. 
E.g. Home page has smart-banner for app1, and 3rd level page got app2. If we close smart-banner for app1, we won't render smart-banner app2.