### PR TITLE
Add travis integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: node_js
+node_js:
+  - "node"
+  - "lts/*"
+  - "8"
+  - "7"
+  - "6"
+script:
+  - npm run build
+  - npm run lint
+

--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ The following commands are available for compiling the project:
 | ------- | ------ |
 | `npm install` | Installs the required dependencies |
 | `npm run build` | Builds the application JavaScript. |
+| `npm run lint` | Check for linter error. |
+| `npm run eslint -- --fix index.js` | Fix linter error automatically. |
 
 ## See also
 

--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ var mixins = {
 		appMeta: 'apple-itunes-app',
 		iconRels: ['apple-touch-icon-precomposed', 'apple-touch-icon'],
 		getStoreLink: function () {
-			return 'https://itunes.apple.com/' + this.options.appStoreLanguage + '/app/id' + this.appId + "?mt=8";
+			return 'https://itunes.apple.com/' + this.options.appStoreLanguage + '/app/id' + this.appId + '?mt=8';
 		}
 	},
 	android: {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   },
   "devDependencies": {
     "browserify": "^16.2.2",
-    "closurecompiler": "^1.6.1"
+    "closurecompiler": "^1.6.1",
+    "eslint": "^5.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "build": "browserify index.js -s SmartBanner | ccjs - > dist/smart-app-banner.js",
-    "lint": "eslint index.js"
+    "lint": "eslint index.js",
+    "eslint": "eslint"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This way, linter errors won't polute upstream repo :tada:

You can have a look at the successful travis run here:
* https://travis-ci.com/GabLeRoux/smart-app-banner
* https://travis-ci.com/GabLeRoux/smart-app-banner/builds/80221613

It only takes ~2 minutes to run